### PR TITLE
Initial support of ast1060

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ path = "lib/counters"
 anyhow = { version = "1.0.31", default-features = false, features = ["std"] }
 array-init = { version = "2.1.0" }
 arrayvec = { version = "0.7.4", default-features = false }
+aspeed-ddk = { git = "https://github.com/aspeedtech-bmc/ast1060-rust.git" }
+ast1060-pac = { git = "https://github.com/aspeedtech-bmc/ast1060-pac.git" }
 atty = { version = "0.2", default-features = false }
 bitfield = { version = "0.13", default-features = false }
 bitflags = { version = "2.5.0", default-features = false }

--- a/app/ast1060-starter/Cargo.toml
+++ b/app/ast1060-starter/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+edition = "2021"
+readme = "README.md"
+name = "ast1060-starter"
+version = "0.1.0"
+
+[features]
+#dump = ["kern/dump"]
+jtag-halt = []
+
+[dependencies]
+ast1060-pac = { workspace = true, features = ["rt"] }
+cortex-m = { workspace = true }
+cortex-m-rt = { workspace = true }
+kern = { path = "../../sys/kern" }
+
+# this lets you use `cargo fix`!
+[[bin]]
+name = "ast1060-starter"
+test = false
+doctest = false
+bench = false
+
+[lints]
+workspace = true

--- a/app/ast1060-starter/README.md
+++ b/app/ast1060-starter/README.md
@@ -1,0 +1,1 @@
+# AST1060 minimum application

--- a/app/ast1060-starter/app.toml
+++ b/app/ast1060-starter/app.toml
@@ -1,0 +1,24 @@
+name = "ast1060-starter"
+target = "thumbv7em-none-eabihf"
+board = "ast1060-rot"
+chip = "../../chips/ast1060"
+stacksize = 1024 
+
+[kernel]
+name = "ast1060-starter"
+requires = {flash = 20000, ram = 3072}
+
+[tasks.jefe]
+name = "task-jefe"
+priority = 0
+max-sizes = {flash = 8192, ram = 4096}
+start = true
+stacksize = 1536
+notifications = ["fault", "timer"]
+
+[tasks.idle]
+name = "task-idle"
+priority = 5
+max-sizes = {flash = 128, ram = 256}
+stacksize = 256
+start = true

--- a/app/ast1060-starter/src/main.rs
+++ b/app/ast1060-starter/src/main.rs
@@ -12,9 +12,7 @@ use cortex_m_rt::entry;
 use ast1060_pac::Peripherals;
 
 #[cfg(feature = "jtag-halt")]
-use core::ptr;
-#[cfg(feature = "jtag-halt")]
-use core::ptr::addr_of;
+use core::ptr::{self, addr_of};
 
 #[entry]
 fn main() -> ! {
@@ -48,6 +46,9 @@ fn main() -> ! {
 fn jtag_halt() {
     static mut HALT : u32 = 1;
 
+    // This is a hack to halt the CPU in JTAG mode.
+    // It writes a value to a volatile memory location
+    // Break by jtag and set val to zero to continue.
     loop {
         let val;
         unsafe {

--- a/app/ast1060-starter/src/main.rs
+++ b/app/ast1060-starter/src/main.rs
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#![no_std]
+#![no_main]
+
+// We have to do this if we don't otherwise use it to ensure its vector table
+// gets linked in.
+
+use cortex_m_rt::entry;
+use ast1060_pac::Peripherals;
+
+#[cfg(feature = "jtag-halt")]
+use core::ptr;
+#[cfg(feature = "jtag-halt")]
+use core::ptr::addr_of;
+
+#[entry]
+fn main() -> ! {
+
+    // This code just forces the ast1060 pac to be linked in.
+    let peripherals = unsafe {
+        Peripherals::steal()
+    };
+    peripherals.scu.scu000().modify(|_, w| {
+        w
+    });
+    peripherals.scu.scu41c().modify(|_, w| {
+        // Set the JTAG pinmux to 0x1f << 25
+        w.enbl_armtmsfn_pin().bit(true)
+            .enbl_armtckfn_pin().bit(true)
+            .enbl_armtrstfn_pin().bit(true)
+            .enbl_armtdifn_pin().bit(true)
+            .enbl_armtdofn_pin().bit(true)
+    });
+
+    #[cfg(feature = "jtag-halt")]
+    jtag_halt();
+
+    // Default boot speed, until we bother raising it:
+    const CYCLES_PER_MS: u32 = 16_000;
+
+    unsafe { kern::startup::start_kernel(CYCLES_PER_MS) }
+}
+
+#[cfg(feature = "jtag-halt")]
+fn jtag_halt() {
+    static mut HALT : u32 = 1;
+
+    loop {
+        let val;
+        unsafe {
+            val = ptr::read_volatile(addr_of!(HALT));
+        }
+
+        if val == 0 {
+            break;
+        }
+    }
+}

--- a/boards/ast1060-rot.toml
+++ b/boards/ast1060-rot.toml
@@ -1,0 +1,4 @@
+# AST1060 RoT board configuration
+[probe-rs]
+chip-name = "AST1060"
+

--- a/chips/ast1060/chip.toml
+++ b/chips/ast1060/chip.toml
@@ -1,0 +1,10 @@
+# AST1060 SoC peripheral definitions
+
+[hace_controller]
+address = 0x7e6d0000
+size = 0x400
+
+[uart]
+address = 0x7e784000
+size = 0x1000
+interrupts = { irq = 8 }

--- a/chips/ast1060/memory.toml
+++ b/chips/ast1060/memory.toml
@@ -1,0 +1,21 @@
+[[flash]]
+address = 0x00000000
+size = 32768
+read = true
+write = true
+execute = true
+
+[[ram]]
+address = 0x20000
+size = 65536
+read = true
+write = true
+execute = true
+
+[[sboot_hdr]]
+address = 0x400
+size = 32
+read = true
+write = false
+execute = false
+

--- a/chips/ast1060/openocd.gdb
+++ b/chips/ast1060/openocd.gdb
@@ -1,0 +1,12 @@
+target extended-remote :3341
+
+# print demangled symbols
+set print asm-demangle on
+
+# set backtrace limit to not have infinite backtrace loops
+set backtrace limit 32
+
+# detect hard faults
+break HardFault
+
+monitor arm semihosting enable


### PR DESCRIPTION
1. Build the firmware image:
```
$ cargo xtask dist app/ast1060-starter/app.toml
$ gen_uart_booting_image.sh target/ast1060-starter/dist/default/final.bin \
                            target/ast1060-starter/dist/default/uart_final.bin
```

2. Using uart_final.bin for boot from UART.

3. Using humility over jtag to verify
```
$ humility -e env.json -t ast1060 tasks
humility: attached via JLink
system time = 114057
ID TASK                       GEN PRI STATE
 0 jefe                         0   0 recv, notif: fault timer(T+43)
 1 idle                         0   5 RUNNING

$ humility -e env.json -t ast1060 stackmargin
humility: attached via JLink
ID TASK                STACKBASE  STACKSIZE   MAXDEPTH     MARGIN
 0 jefe               0x21000          1536        272       1264
 1 idle               0x20c00           256        104        152

```
env.json
```json
{
        "ast1060" : {
                "probe" : "jlink",
                "archive" : "target/ast1060-starter/dist/default/build-ast1060-starter-image-default.zip"
        }
}
```
Note: the humility has some bug in gdb connection.

TODO:
- Adding Secure Boot Header within final.bin
- JTAG halt at main configured by features